### PR TITLE
l2cap_con: add include for writev(2) declaration

### DIFF
--- a/l2cap_con.c
+++ b/l2cap_con.c
@@ -13,6 +13,7 @@
 #include <bluetooth/hci_lib.h>
 #include <fcntl.h>
 #include <sys/ioctl.h>
+#include <sys/uio.h>
 
 #ifdef BT_POWER
 #warning "BT_POWER is already defined."


### PR DESCRIPTION
Just to avoid a warning when building.