### PR TITLE
Don't set MTU on socket

### DIFF
--- a/l2cap_con.c
+++ b/l2cap_con.c
@@ -154,32 +154,12 @@ int acl_send_data (const char *bdaddr_dst, unsigned short cid, const unsigned ch
   return ret;
 }
 
-#define L2CAP_MTU 1024
-
 static void l2cap_setsockopt(int fd)
 {
-  struct l2cap_options l2o;
-  socklen_t len = sizeof(l2o);
-
   int opt = L2CAP_LM_MASTER;
   if (setsockopt(fd, SOL_L2CAP, L2CAP_LM, &opt, sizeof(opt)) < 0)
   {
     perror("setsockopt L2CAP_LM");
-  }
-
-  memset(&l2o, 0, sizeof(l2o));
-  if(getsockopt(fd, SOL_L2CAP, L2CAP_OPTIONS, &l2o, &len) < 0)
-  {
-    perror("getsockopt L2CAP_OPTIONS");
-  }
-  else
-  {
-    l2o.omtu = L2CAP_MTU;
-    l2o.imtu = L2CAP_MTU;
-    if(setsockopt(fd, SOL_L2CAP, L2CAP_OPTIONS, &l2o, sizeof(l2o)) < 0)
-    {
-      perror("setsockopt L2CAP_OPTIONS");
-    }
   }
 
   /*if (fcntl(fd, F_SETFL, O_NONBLOCK) < 0)


### PR DESCRIPTION
I have spent some time debugging this :) I was trying to use the proxy between a PS4 and a Dual Shock. Everything seemed to be fine, except that after the PS4 sent its "big" SDP packet (797 bytes), nothing happened and the outgoing connection to the PS4 on HID PSMs timed out.

Removing the MTU option fixed this. My guess (I'm no BT expert) is that the PS4 did not like a "fragmented" packet that wasn't actually fragmented (since the MTU was 1024, ace_send_data only had to call writev once). Now everything works fine. This is only a problem the first time the proxy is used with a given BTADDR of course, since subsequent connexions do not trigger the PS4 -> DS SDP stuff.