### PR TITLE
Arguments parsing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+*.o
+l2cap_proxy
+

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Run the proxy
 ```
 sudo service bluetooth stop  
 sudo hciconfig hci<X> up pscan  
-sudo ./l2cap_proxy <master-bdaddr> <dongle-bdaddr> <device-class>  
+sudo ./l2cap_proxy -h <master-bdaddr> [-d <dongle-bdaddr>] [-c <device-class>]
 ```
 ```
 <X>: the device number (type hciconfig to list the available adapters)  

--- a/l2cap_con.c
+++ b/l2cap_con.c
@@ -154,32 +154,12 @@ int acl_send_data (const char *bdaddr_dst, unsigned short cid, const unsigned ch
   return ret;
 }
 
-#define L2CAP_MTU 1024
-
 static void l2cap_setsockopt(int fd)
 {
-  struct l2cap_options l2o;
-  socklen_t len = sizeof(l2o);
-
   int opt = L2CAP_LM_MASTER;
   if (setsockopt(fd, SOL_L2CAP, L2CAP_LM, &opt, sizeof(opt)) < 0)
   {
     perror("setsockopt L2CAP_LM");
-  }
-
-  memset(&l2o, 0, sizeof(l2o));
-  if(getsockopt(fd, SOL_L2CAP, L2CAP_OPTIONS, &l2o, &len) < 0)
-  {
-    perror("getsockopt L2CAP_OPTIONS");
-  }
-  else
-  {
-    l2o.omtu = L2CAP_MTU;
-    l2o.imtu = L2CAP_MTU;
-    if(setsockopt(fd, SOL_L2CAP, L2CAP_OPTIONS, &l2o, sizeof(l2o)) < 0)
-    {
-      perror("setsockopt L2CAP_OPTIONS");
-    }
   }
 
   /*if (fcntl(fd, F_SETFL, O_NONBLOCK) < 0)


### PR DESCRIPTION
I added basic command-line option parsing in preparation to new options to set link keys. The host address is still passed as argument but the dongle address and device class are now specified via the optional -d/--dongle and -c/--class options.